### PR TITLE
Upgrade haystack-logback-custom-appender to 0.1.8, to pick up the change

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <httpclient.version>4.5.3</httpclient.version>
         <jcl-slf4j.version>1.7.7</jcl-slf4j.version>
 
-        <haystack.logback.metrics.appender.version>0.1.3</haystack.logback.metrics.appender.version>
+        <haystack.logback.metrics.appender.version>0.1.8</haystack.logback.metrics.appender.version>
         <scala.major.version>2</scala.major.version>
         <scala.minor.version>11</scala.minor.version>
         <scala.tiny.version>8</scala.tiny.version>


### PR DESCRIPTION
that correctly shuts down the background threads when the custom
appender stops.